### PR TITLE
allow importing the whole directory

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,20 @@
+import pandas as pd
+import numpy as np
+import seaborn as sns
+
+from sqlalchemy import *
+from sqlalchemy.sql import label, select, literal_column
+from sqlalchemy.sql.expression import cast
+
+import datetime
+
+now = datetime.datetime.now
+timedelta = datetime.timedelta
+
+from .warehouse import describe, Warehouse
+from .table_names import public, wild_west
+
+from matplotlib import pyplot
+
+# To avoid missing font warnings, set a default font that exists
+sns.set(font="DejaVu Sans")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@
 pandas == 0.23.4
 sqlalchemy == 1.2.15
 snowflake.sqlalchemy == 1.1.11
+seaborn==0.9.0

--- a/table_names.py
+++ b/table_names.py
@@ -1,4 +1,4 @@
-from warehouse import Warehouse
+from .warehouse import Warehouse
 
 def initialize_schema_object(klass):
     schema_name = klass.schema_name
@@ -30,16 +30,20 @@ class SchoolMint:
 class WildWest:
     schema_name = 'wild_west'
 
-initialize_schema_object(InformationSchema)
-initialize_schema_object(InfoTeam)
-initialize_schema_object(PowerSchool)
-initialize_schema_object(Public)
-initialize_schema_object(SchoolMint)
-initialize_schema_object(WildWest)
+# initialize_schema_object(InformationSchema)
+# information_schema = InformationSchema()
 
-information_schema = InformationSchema()
-info_team = InfoTeam()
-powerschool = PowerSchool()
+# initialize_schema_object(InfoTeam)
+# info_team = InfoTeam()
+
+# initialize_schema_object(PowerSchool)
+# powerschool = PowerSchool()
+
+# initialize_schema_object(SchoolMint)
+# schoolmint = SchoolMint()
+
+initialize_schema_object(Public)
 public = Public()
-schoolmint = SchoolMint()
+
+initialize_schema_object(WildWest)
 wild_west = WildWest()

--- a/warehouse.py
+++ b/warehouse.py
@@ -1,6 +1,6 @@
 import pandas
 
-from credentials import snowflake_config
+from .credentials import snowflake_config
 from sqlalchemy.engine.url import URL
 from sqlalchemy import create_engine, MetaData, Table
 from sqlalchemy.engine import reflection


### PR DESCRIPTION
I made a few tweaks so that most schemas wouldn't preload.
Also, I wanted to be able to just do "import spswarehouse" and get the entire package, so I added a __init__.py file.

I didn't realize this, but we'll need to rename the repository to not have a hyphen so that we can import it as a package. How about just spswarehouse?