### PR TITLE
Default Warehouse.reflect() schema argument to credentials value

### DIFF
--- a/warehouse.py
+++ b/warehouse.py
@@ -70,7 +70,7 @@ class Warehouse:
         """
         return pandas.read_sql(sql, self.engine)
 
-    def reflect(self, table_or_view, schema='public'):
+    def reflect(self, table_or_view, schema=snowflake_config['schema']):
         """
         reflect: table name, schema name (optional) -> SQLAlchemy Table object
         reflect: view name,  schema name (optional) -> SQLAlchemy Table object
@@ -94,11 +94,7 @@ class Warehouse:
         if table is not None:
             return table
 
-        # apparently, sqlalchemy is pretty picky about the public schema
-        if schema == 'public':
-            table = Table(table_or_view, self.meta, autoload=True)
-        else:
-            table = Table(table_or_view, self.meta, autoload=True, schema=schema)
+        table = Table(table_or_view, self.meta, autoload=True, schema=schema)
 
         # sets the column names explicitly on the instance so that tab-completion is easy
         for c in table.columns:


### PR DESCRIPTION
If `public` is expected, regardless of your credentials settings, I can drop this change. I just got confused when loading `wild_west.dim_stacy_test` with my credentials set to `wild_west`.

I also tested with different credential settings and `wild_west.dim_stacy_test` and `public.dim_stacy`, and creating `Table()` with `public` schema is fine even if you pass in the argument.