### PR TITLE
Fix import error in table_utils

### DIFF
--- a/spswarehouse/table_utils.py
+++ b/spswarehouse/table_utils.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import numpy as np
 
-from warehouse import Warehouse
+from .warehouse import Warehouse
 
 ENCODING='utf-8'
 INSERT_BATCH_SIZE=50


### PR DESCRIPTION
Fixes bug reported by Howard for `from spswarehouse.table_utils import *` throwing an error. 