### PR TITLE
Bug fix for CSV uploads

### DIFF
--- a/spswarehouse/table_utils.py
+++ b/spswarehouse/table_utils.py
@@ -39,6 +39,8 @@ def upload_df(
     '''
     end_index = len(df) if end_index is None else end_index
 
+    df = sanitize_df_for_upload(df)
+    
     print(str(end_index - start_index) + ' rows to insert')
     while start_index < end_index:
         df_insert = df[start_index:start_index+INSERT_BATCH_SIZE]


### PR DESCRIPTION
We sanitize column names for uploading to the Snowflake warehouse. For example a column "Foo Bar" becomes "Foo_Bar". 

This happens whenever we programmatically generate a `CREATE TABLE` statement, e.g., `create_table_stmt*()`.

However, the new column names were only persisted if a `dataframe` was passed in. If uploading from CSV and the column names had changed, that column data would go missing. 

The fix is to sanitize the column names when `upload*()` is called, so it's consistent between the `CREATE` and the `INSERT` paths, regardless of data source. 