### PR TITLE
Google Sheets: allow importing module with empty private_key

### DIFF
--- a/spswarehouse/googlesheets.py
+++ b/spswarehouse/googlesheets.py
@@ -21,13 +21,27 @@ def initialize_credentials():
 
     You still need to share spreadsheets with the service account email.
     """
+
+    # This prevents us from erroring out trying to construct credentials
+    # from incomplete information.
+    service_account = google_config.get('service-account', {})
+    private_key = service_account.get('private_key', None)
+    if not private_key:
+        print(
+            "You're missing Google service account credentials",
+            "in credentials.py.",
+            "To access your Google spreadsheet data,",
+            "fill out the Google service account information."
+        )
+        return None
+
     credentials = ServiceAccountCredentials.from_json_keyfile_dict(
         google_config['service-account'],
         scopes=google_config['scopes'],
     )
     print(
         'To access your Google spreadsheet data, share the spreadsheet with {email}'
-        .format(email=google_config['service-account']['client_email'])
+        .format(email=get_google_service_account_email())
     )
     return credentials
 
@@ -44,4 +58,4 @@ def create_client(credentials):
 credentials = initialize_credentials()
 
 # This is a wrapper for gspread.Client
-GoogleSheets = create_client(credentials)
+GoogleSheets = None if credentials is None else create_client(credentials)


### PR DESCRIPTION
Don't error out when importing `googlesheets` module with incomplete Google service account credentials.

 - Prints message prompting user to fill out `credentials.py`
 - Sets `GoogleSheets` to `None`

You can re-import after filling out `private_key` and get access. 