### PR TITLE
Updated Google Drive auth to handle refreshes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spswarehouse",
-    version="0.6.1",
+    version="0.6.2",
     author="Summit Public Schools; Harry Li Consulting, LLC",
     author_email="warehouse@summitps.org",
     description="Summit Public Schools Snowflake warehouse",


### PR DESCRIPTION
The way we were passing Google credentials to pydrive was a bit of a hack and caused an exception after an hour when we needed to refresh the access token.

This instantiates it in the proper way so that you no longer have to reset the Jupyter kernel every hour