### PR TITLE
PowerSchool Upload Fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spswarehouse",
-    version="0.6.1",
+    version="0.6.2",
     author="Summit Public Schools; Harry Li Consulting, LLC",
     author_email="warehouse@summitps.org",
     description="Summit Public Schools Snowflake warehouse",

--- a/spswarehouse/powerschool/powerschool.py
+++ b/spswarehouse/powerschool/powerschool.py
@@ -604,7 +604,7 @@ class PowerSchool:
         4. have a column called "student_number"
         """
         
-        import_data = pd.read_csv(filename)
+        import_data = pd.read_csv(filename, dtype=str)
         final_student_number = import_data.iloc[-1]['student_number']
         
         self.upload_csv_quick_import(filename, final_student_number, 'Students')
@@ -621,7 +621,7 @@ class PowerSchool:
         """
         
         # Convert the file to a tab-delimited file
-        import_data = pd.read_csv(filename, encoding='mac_roman')
+        import_data = pd.read_csv(filename, encoding='mac_roman', dtype=str)
         
         new_filename = filename + ".tsv"
         


### PR DESCRIPTION
This updates two of the `read_csv()` calls in `powerschool.py` to explicitly read the data in the CSV as strings. This is necessary to preserve leading zeros when re-saving the file as a .tsv, as well as to get around an occasional bug with comparing the student_number in the file with the student_number in PowerSchool ([Asana task](https://app.asana.com/0/1203184926617908/1206843662644716)).