### PR TITLE
Switching Canvas authentication mechanism

### DIFF
--- a/sample_code/Canvas Example.ipynb
+++ b/sample_code/Canvas Example.ipynb
@@ -24,15 +24,8 @@
    "source": [
     "# We can't use the system credentials since we're importing our local spswarehouse code\n",
     "canvas_config = {\n",
-    "    \"client_id\": \"250260000000000002\",\n",
-    "    \"client_secret\": \"[IN LASTPASS]\",\n",
+    "    \"api_token\": \"[generate in your Profile > Settings page in Canvas]\",\n",
     "    \"host\": \"https://summitps.beta.instructure.com\", # Defaulting to Beta for the sample notebook!\n",
-    "    \"token\": {\n",
-    "        \"access_token\": \"[IN LASTPASS]\",\n",
-    "        \"refresh_token\": \"[IN LASTPASS]\",\n",
-    "        \"token_type\": \"Bearer\",\n",
-    "        \"expires_in\": \"3600\",\n",
-    "    }\n",
     "}\n",
     "\n",
     "canvas = spswarehouse.canvas.CanvasClient(config=canvas_config)"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="spswarehouse",
-    version="0.7.2",
+    version="0.7.3",
     author="Summit Public Schools; Harry Li Consulting, LLC",
     author_email="warehouse@summitps.org",
     description="Summit Public Schools Snowflake warehouse",

--- a/spswarehouse/credentials.py.template
+++ b/spswarehouse/credentials.py.template
@@ -45,16 +45,8 @@ calpads_config = {
 }
 
 canvas_config = {
-	# Client ID and secret can be created in "Developer Keys" within the Canvas admin
-	# At Summit, please used the stored credentials in LastPass
-	"client_id": "250260000000000002",
-	"client_secret": "",
+	# To generate an API token, go to your Profile in Canvas, click Settings > + New Access Token
+	"api_token": "",
 	"host": "https://summitps.instructure.com", # Production
 	# "host": "https://summitps.beta.instructure.com", # Beta
-	"token": {
-		"access_token": "",
-		"refresh_token": "",
-		"token_type": "Bearer",
-		"expires_in": "3600",
-	}
 }

--- a/spswarehouse/requirements.txt
+++ b/spswarehouse/requirements.txt
@@ -11,6 +11,6 @@ gspread-dataframe==3.3.0
 gspread-formatting==1.1.2
 PyDrive2==1.15.0
 "duct-tape>0.26.0"
-requests-oauthlib==1.3.1
+requests==2.32.0
 # This probably works with selenium==3.141.0 too, but is not as thoroughly tested
 selenium==4.7.2


### PR DESCRIPTION
Instead of using the auth/refresh token, Canvas allows you to create everlasting tokens on your user profile. These make more sense for what we do.